### PR TITLE
Replace Deno.env() with Deno.env.toObject()

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -1,4 +1,4 @@
-const env = Deno.env();
+const env = Deno.env.toObject();
 
 export const APP_HOST = env.APP_HOST || "127.0.0.1";
 export const APP_PORT = env.APP_PORT || 4000;


### PR DESCRIPTION
With the  latest release, `deno 1.0.0-rc1`, the API has changed, `Deno.env()` replaced with `Deno.env.toObject()`.